### PR TITLE
Phase2 enhancement

### DIFF
--- a/src/app/core/services/issue.service.ts
+++ b/src/app/core/services/issue.service.ts
@@ -293,6 +293,13 @@ export class IssueService {
     );
   }
 
+  /**
+   * Obtain an observable containing an array of issues titles ordered by latest ID first
+   */
+  getIssueTitles(): Observable<string[]> {
+    return this.issues$.pipe(map((issues) => issues.map((issue) => issue.title).reverse()));
+  }
+
   reset(resetSessionId: boolean) {
     if (resetSessionId) {
       this.sessionId = undefined;

--- a/src/app/phase-bug-reporting/new-issue/new-issue.component.html
+++ b/src/app/phase-bug-reporting/new-issue/new-issue.component.html
@@ -5,10 +5,15 @@
     <div class="row">
       <div class="column left">
         <mat-form-field>
-          <input id="title" formControlName="title" matInput placeholder="Title" required maxlength="256" />
+          <input id="title" formControlName="title" matInput placeholder="Title" required maxlength="256" [matAutocomplete]="auto" />
           <mat-error *ngIf="title.errors && title.errors['required'] && (title.touched || title.dirty)"> Title required. </mat-error>
           <mat-error *ngIf="title.errors && title.errors['maxlength']"> Title cannot exceed 256 characters. </mat-error>
           <mat-hint *ngIf="title.value?.length >= 206"> {{ 256 - title.value?.length }} characters remaining. </mat-hint>
+          <mat-autocomplete #auto="matAutocomplete">
+            <mat-option *ngFor="let option of filteredOptions | async" [value]="option">
+              {{ option }}
+            </mat-option>
+          </mat-autocomplete>
         </mat-form-field>
 
         <div style="margin: 10px 0 10px 0">

--- a/src/app/phase-bug-reporting/new-issue/new-issue.component.ts
+++ b/src/app/phase-bug-reporting/new-issue/new-issue.component.ts
@@ -19,7 +19,7 @@ export class NewIssueComponent implements OnInit {
   isFormPending = false;
   submitButtonText: string;
   filteredOptions: Observable<string[]>;
-  options: string[];
+  private options: string[];
 
   constructor(
     private issueService: IssueService,
@@ -86,7 +86,7 @@ export class NewIssueComponent implements OnInit {
   }
 
   private getTitles() {
-    if (this.issueService === undefined) {
+    if (!this.issueService) {
       this.options = [];
       return;
     }

--- a/src/app/phase-bug-reporting/new-issue/new-issue.component.ts
+++ b/src/app/phase-bug-reporting/new-issue/new-issue.component.ts
@@ -1,8 +1,8 @@
 import { Component, OnInit } from '@angular/core';
 import { AbstractControl, FormBuilder, FormGroup, NgForm, Validators } from '@angular/forms';
-import { Observable } from 'rxjs';
 import { Router } from '@angular/router';
-import { finalize, startWith, map } from 'rxjs/operators';
+import { Observable } from 'rxjs';
+import { finalize, map, startWith } from 'rxjs/operators';
 import { Issue } from '../../core/models/issue.model';
 import { ErrorHandlingService } from '../../core/services/error-handling.service';
 import { IssueService } from '../../core/services/issue.service';
@@ -86,7 +86,12 @@ export class NewIssueComponent implements OnInit {
   }
 
   private getTitles() {
-    return this.issueService.getIssueTitles().subscribe((titles: string[]) => (this.options = titles));
+    if (this.issueService === undefined) {
+      this.options = [];
+      return;
+    }
+
+    this.issueService.getIssueTitles().subscribe((titles: string[]) => (this.options = titles));
   }
 
   get title() {


### PR DESCRIPTION
Summary:
Currently, if a student has previously reported many similar issues and is in the midst of reporting a new issue, he may forget what issues have previously been reported. In such a case, he would have to discard the unsaved changes to return to the main page and view the issue list.

This enhancement adds an autocomplete functionality to the input tag of the new-issue form. This will display a dropdown list of previously reported issues that matches the new issue title inputted. This makes it easy for the user to see if the current issue has already been reported.

Changes Made:
- Add a getIssueTitles method in the Issue Service that returns an Observable<string[]>
- Add an options and filteredOptions attribute in new-issue.component to store a list of reported issue titles
- Add a <mat-autocomplete> tag in the new-issue.component template to display any matching issue titles

Preview of Changes:
![image](https://github.com/LJXSean/CATcher/assets/110801974/c7c29d15-312c-41d5-936b-ad487eb32d92)

![image](https://github.com/LJXSean/CATcher/assets/110801974/65476e0a-ea99-4e92-ac5d-0e47deb22c2c)
